### PR TITLE
Fix Linear Regression Slope Issue

### DIFF
--- a/linear_regression/Linear Regression.ipynb
+++ b/linear_regression/Linear Regression.ipynb
@@ -347,7 +347,7 @@
     "ax = fig.add_subplot(111)\n",
     "ax.scatter(x, y)\n",
     "ax.axline([0, w[0]], slope=w[1], c='b')\n",
-    "ax.axline([0, b], slope=m, c='g')\n",
+    "ax.axline([0, b], slope=m[1], c='g')\n",
     "for i in range(5):\n",
     "    ax.plot([x[i], x[i]], [y[i], y_hat[i]], c='r', linewidth=0.5)"
    ]


### PR DESCRIPTION
There is a issue while running the code snippet ndarray is passed instead of float value for the axline slope.
Earlier
    ax.axline([0, b], slope=m, c='g')
Changed to
   ax.axline([0, b], slope=m[1], c='g')

This issue is observed in 29 August class while walkthrough.